### PR TITLE
Fix missing backwards compatibility for $GLOBALS['quick_cache']

### DIFF
--- a/src/includes/plugin.php
+++ b/src/includes/plugin.php
@@ -14,6 +14,7 @@ require_once dirname(__FILE__).'/stub.php';
 if (!Conflicts::check()) {
     $GLOBALS[GLOBAL_NS]  = new Plugin();
     $GLOBALS['zencache'] = $GLOBALS[GLOBAL_NS]; // Back compat.
+    $GLOBALS['quick_cache'] = $GLOBALS[GLOBAL_NS]; // Back compat.
 
     add_action('plugins_loaded', function() {
         require_once dirname(__FILE__).'/api.php';


### PR DESCRIPTION
See websharks/comet-cache#691