### PR TITLE
Hook into plugins_loaded instead of after_setup_theme to call setup()

### DIFF
--- a/src/includes/classes/Plugin.php
+++ b/src/includes/classes/Plugin.php
@@ -197,7 +197,7 @@ class Plugin extends AbsBaseAp
         }
         /* -------------------------------------------------------------- */
 
-        add_action('after_setup_theme', [$this, 'setup']);
+        add_action('plugins_loaded', [$this, 'setup']);
         register_activation_hook(PLUGIN_FILE, [$this, 'activate']);
         register_deactivation_hook(PLUGIN_FILE, [$this, 'deactivate']);
     }

--- a/src/includes/stub.php
+++ b/src/includes/stub.php
@@ -47,3 +47,11 @@ class_alias(__NAMESPACE__.'\\Classes\\AdvancedCache', 'WebSharks\\Comet_Cache\\A
 class_alias(__NAMESPACE__.'\\Classes\\AdvCacheBackCompat', 'WebSharks\\Comet_Cache\\Pro\\AdvCacheBackCompat');
 class_alias(__NAMESPACE__.'\\Classes\\AdvancedCache', 'WebSharks\\Comet_Cache\\Pro\\AdvancedCache');
 /*[/pro]*/
+
+// Fixes PHP Fatal error with upgrades from v160227
+class_alias(__NAMESPACE__.'\\Classes\\AdvCacheBackCompat', 'WebSharks\\CometCache\\AdvCacheBackCompat');
+class_alias(__NAMESPACE__.'\\Classes\\AdvancedCache', 'WebSharks\\CometCache\\AdvancedCache');
+/*[pro strip-from="lite"]*/
+class_alias(__NAMESPACE__.'\\Classes\\AdvCacheBackCompat', 'WebSharks\\CometCache\\Pro\\AdvCacheBackCompat');
+class_alias(__NAMESPACE__.'\\Classes\\AdvancedCache', 'WebSharks\\CometCache\\Pro\\AdvancedCache');
+/*[/pro]*/


### PR DESCRIPTION
See websharks/comet-cache#716.

Note this also includes a fix for a fatal error when upgrading from v160227; see https://github.com/websharks/comet-cache-pro/commit/b9650769a30b6333f35290ec98c13391b7ed242f.