### PR TITLE
Bump required WordPress version from v4.1 to v4.2.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Comet Cache ===
 
 Stable tag: 160227
-Requires at least: 4.1
+Requires at least: 4.2
 Tested up to: 4.5-alpha
 Text Domain: comet-cache
 


### PR DESCRIPTION
See websharks/comet-cache#706