### PR TITLE
Only auto-clear the cache when Settings → General options are saved

### DIFF
--- a/src/includes/traits/Plugin/WcpSettingUtils.php
+++ b/src/includes/traits/Plugin/WcpSettingUtils.php
@@ -15,14 +15,19 @@ trait WcpSettingUtils
      */
     public function autoClearCacheOnSettingChanges()
     {
-        $counter          = 0; // Initialize.
-        $pagenow          = !empty($GLOBALS['pagenow']) ? $GLOBALS['pagenow'] : '';
-        $settings_updated = !empty($_REQUEST['settings-updated']);
+        $counter           = 0; // Initialize.
+        $pagenow           = !empty($GLOBALS['pagenow']) ? $GLOBALS['pagenow'] : '';
+        $other_option_page = !empty($_REQUEST['page']);
+        $settings_updated  = !empty($_REQUEST['settings-updated']);
 
-        if (!is_null($done = &$this->cacheKey('autoClearCacheOnSettingChanges', [$pagenow, $settings_updated]))) {
+        if (!is_null($done = &$this->cacheKey('autoClearCacheOnSettingChanges', [$pagenow, $other_option_page, $settings_updated]))) {
             return $counter; // Already did this.
         }
         $done = true; // Flag as having been done.
+
+        if ($pagenow === 'options-general.php' && $other_option_page) {
+            return $counter; // Nothing to do. See: https://git.io/viYqE
+        }
 
         if ($pagenow === 'options-general.php' && $settings_updated) {
             $this->addWpHtaccess(); // Update .htaccess if applicable


### PR DESCRIPTION
Comet Cache was too aggressive and did not consider that other plugins
may be using `options-general.php` for their settings page.

See websharks/comet-cache#825