### PR TITLE
Feature/465

### DIFF
--- a/src/includes/classes/VsUpgrades.php
+++ b/src/includes/classes/VsUpgrades.php
@@ -43,6 +43,7 @@ class VsUpgrades extends AbsBase
         $this->fromZenCache();
         $this->fromLte160227();
         $this->fromLte160521();
+        $this->fromLte160709();
     }
 
     /**
@@ -257,6 +258,18 @@ class VsUpgrades extends AbsBase
             if ($is_apache) {
                 $this->plugin->enqueueMainNotice(sprintf(__('<strong>New %1$s Feature!</strong> This release of %1$s includes a whole new panel for Apache Performance Tuning. Visit the <a href="%2$s">settings</a> and see the new options in <strong>Comet Cache → Plugin Options → Apache Optimizations</strong>.', SLUG_TD), esc_html(NAME), esc_attr(add_query_arg(urlencode_deep(['page' => GLOBAL_NS]), self_admin_url('/admin.php')))));
             }
+        }
+    }
+
+    /**
+     * Before we replaced the Pro Plugin Updater system with the WordPress Plugin Update system.
+     *
+     * @since $v
+     */
+    protected function fromLte160709()
+    {
+        if (version_compare($this->prev_version, '160709', '<=')) {
+            $this->plugin->dismissMainNotice('new-pro-version-available'); // Dismiss any existing notices like this; upgrade notices are handled by WordPress now.
         }
     }
 }

--- a/src/includes/traits/Plugin/UpdateUtils.php
+++ b/src/includes/traits/Plugin/UpdateUtils.php
@@ -180,6 +180,7 @@ trait UpdateUtils
         if ($latest_version && $latest_package && version_compare($latest_version, VERSION, '>')) {
             $report->response[$plugin_basename] = (object) [
                 'id'          => 0,
+                'autoupdate'  => true,
                 'url'         => $plugin_url,
                 'slug'        => $plugin_slug,
                 'plugin'      => $plugin_basename,

--- a/src/includes/traits/Plugin/UpdateUtils.php
+++ b/src/includes/traits/Plugin/UpdateUtils.php
@@ -180,7 +180,6 @@ trait UpdateUtils
         if ($latest_version && $latest_package && version_compare($latest_version, VERSION, '>')) {
             $report->response[$plugin_basename] = (object) [
                 'id'          => 0,
-                'autoupdate'  => true,
                 'url'         => $plugin_url,
                 'slug'        => $plugin_slug,
                 'plugin'      => $plugin_basename,

--- a/src/includes/traits/Plugin/WcpUpdaterUtils.php
+++ b/src/includes/traits/Plugin/WcpUpdaterUtils.php
@@ -46,7 +46,9 @@ trait WcpUpdaterUtils
                         }
                     }
                     unset($_plugin); // Housekeeping.
-                } elseif ($single_plugin_update && ( is_plugin_active($data['plugin']) || $upgrader_instance->skin->upgrader->skin->plugin_active || $upgrader_instance->skin->upgrader->skin->plugin_network_active)) {
+                } elseif ($single_plugin_update && (is_plugin_active($data['plugin'])
+                        || !empty($upgrader_instance->skin->upgrader->skin->plugin_active)
+                        || !empty($upgrader_instance->skin->upgrader->skin->plugin_network_active))) {
                     $upgrading_active_plugin = true;
                 }
                 if ($upgrading_active_plugin) {


### PR DESCRIPTION
Adds support for automatic background updates as best I can tell. I found it very difficult to test this, so if you can share your test workflow with me I'd appreciate it. I haven't dug deep enough yet to be absolutely sure about how this goes down in WordPress core from start to finish.

Having said that, I _was_ able to get this working on at least one occasion via CRON after this patch was applied. It appears this was caused by a lack of the `autoupdate` property in our implementation. See: [this WP core conditional check](https://github.com/WordPress/WordPress/blob/9383bf8f748e65e38a5ed70a29134d6a2b9d9ddc/wp-admin/includes/class-wp-automatic-updater.php#L158). 